### PR TITLE
fix(#121): add argument to make dialogs non-interactive during build

### DIFF
--- a/build/docker/agent/Dockerfile
+++ b/build/docker/agent/Dockerfile
@@ -9,6 +9,7 @@ COPY --from=carla /home/carla/PythonAPI /opt/carla/PythonAPI
 ARG USERNAME=carla
 ARG USER_UID=999
 ARG USER_GID=$USER_UID
+ARG DEBIAN_FRONTEND=noninteractive
 
 
 # install rendering dependencies for rviz / rqt


### PR DESCRIPTION
# Description

Small fix for #119 to allow for build of docker container not to be interrupted.

Fixes #121

## Time invested

Josef Kircher: 1,5 h

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Does this PR introduce a breaking change?


## Most important changes

added an argument that makes dialogs noninteractive during the build, the declaration as `ARG` does not persist after the container is build so during execution of the container, dialogs will be interactive again.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)

