### PR TITLE
96 feature add development container without carla

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .idea
 
+build/config.local.yml
 
 code/build
 code/log

--- a/build/Taskfile
+++ b/build/Taskfile
@@ -39,6 +39,7 @@ task:install() {
 install:gpu-support() {
     # check if docker-nvidia is installed, to make the project also executable on
     # systems without nvidia GPU.
+
     if [ -z "$(command -v docker-nvidia)" ]
     then
       task:nvidia:enable
@@ -56,6 +57,8 @@ task:update() {
 }
 
 task:nvidia:enable() {
+    # Writes the content of templates/config.nvidia.yml.jinja2 to config.local.yml
+    # This file tells b5 to read docker-compose.nvidia.yml in addition to docker-compose.yml
     template:render --overwrite ask-if-older templates/config.nvidia.yml.jinja2 config.local.yml
 }
 

--- a/build/Taskfile
+++ b/build/Taskfile
@@ -32,11 +32,29 @@ task:shell() {
 ##########################################
 task:install() {
     task:install:git_hooks
+    install:gpu-support
     docker:install
+}
+
+install:gpu-support() {
+    if [ -z "$(command -v docker-nvidia)" ]
+    then
+      task:nvidia:enable
+    else
+      RED='\033[0;31m'
+      NC='\033[0m'
+      echo -e "${RED}######################################################################################${NC}"
+      echo -e "${RED}WARNING: NVIDIA Container Toolkit not installed. The project won't run as expected!${NC}"
+      echo -e "${RED}#####################################################################################${NC}"
+    fi
 }
 
 task:update() {
     docker:update
+}
+
+task:nvidia:enable() {
+    template:render --overwrite ask-if-older templates/config.nvidia.yml.jinja2 config.local.yml
 }
 
 ##########################################

--- a/build/Taskfile
+++ b/build/Taskfile
@@ -37,6 +37,8 @@ task:install() {
 }
 
 install:gpu-support() {
+    # check if docker-nvidia is installed, to make the project also executable on
+    # systems without nvidia GPU.
     if [ -z "$(command -v docker-nvidia)" ]
     then
       task:nvidia:enable

--- a/build/config.yml
+++ b/build/config.yml
@@ -1,2 +1,3 @@
 modules:
+  template:
   docker:

--- a/build/docker-compose.nvidia.yml
+++ b/build/docker-compose.nvidia.yml
@@ -1,5 +1,8 @@
 version: "3"
 
+# This file should contain all nvidia GPU specific configuration.
+# Only loaded of specified in config.local.yml
+
 services:
   carla-simulator:
     deploy:

--- a/build/docker-compose.nvidia.yml
+++ b/build/docker-compose.nvidia.yml
@@ -1,0 +1,26 @@
+version: "3"
+
+services:
+  carla-simulator:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [ gpu ]
+    environment:
+      - DISPLAY
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=all
+
+  agent:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              capabilities: [ gpu ]
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=all
+

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -21,16 +21,6 @@ services:
     command: /bin/bash CarlaUE4.sh -quality-level=Epic -world-port=2000 -resx=800 -resy=600
     image: ghcr.io/nylser/carla:leaderboard
     init: true
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              capabilities: [ gpu ]
-    environment:
-      - DISPLAY
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=all
     expose:
       - 2000
       - 2001
@@ -64,16 +54,8 @@ services:
     command: bash -c "sleep 10 && roslaunch agent/launch/dev.launch"
     logging:
       driver: "local"
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              capabilities: [ gpu ]
     environment:
       - DISPLAY
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=all
       - ROS_MASTER_URI=http://roscore:11311
       - CARLA_SIM_HOST=carla-simulator
       - ROS_HOSTNAME=agent

--- a/build/docker/agent/Dockerfile
+++ b/build/docker/agent/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install -y \
 SHELL ["/bin/bash", "-c"]
 
 # Create and apply the non-root user
+# -f parameter to work in macos (https://unix.stackexchange.com/a/465014), since gid is already in use there
 RUN groupadd --gid $USER_GID $USERNAME -f \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
     && apt-get update \

--- a/build/docker/agent/Dockerfile
+++ b/build/docker/agent/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y \
 SHELL ["/bin/bash", "-c"]
 
 # Create and apply the non-root user
-RUN groupadd --gid $USER_GID $USERNAME \
+RUN groupadd --gid $USER_GID $USERNAME -f \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
     && apt-get update \
     && apt-get install -y sudo \

--- a/build/templates/config.nvidia.yml.jinja2
+++ b/build/templates/config.nvidia.yml.jinja2
@@ -1,4 +1,5 @@
 # Using nvidia GPU:
+# Tells b5 to use docker-compose.nvidia.yml additionally
 modules:
     docker:
         docker_compose_config_overrides:

--- a/build/templates/config.nvidia.yml.jinja2
+++ b/build/templates/config.nvidia.yml.jinja2
@@ -1,0 +1,5 @@
+# Using nvidia GPU:
+modules:
+    docker:
+        docker_compose_config_overrides:
+          - nvidia


### PR DESCRIPTION
# Description

Makes it possible to run the containers on devices without Nvidia GPU. Thereby, CARLA can't be executed because of the missing GPU, however, any command can be run inside the agent container `b5 shell agent`.

Fixes #96 and #124

## Time invested

Tim Dreier: 3h

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Does this PR introduce a breaking change?

Kind of, everyone has to run `b5 install` to write the configuration.

## Most important changes

That the project now also runs on any Unix based system (including macOS, without GPU support).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)

