### PR TITLE
fix(#147): Use pre-extracted .zip file for Carla PythonAPI

### DIFF
--- a/build/docker/agent/Dockerfile
+++ b/build/docker/agent/Dockerfile
@@ -1,4 +1,8 @@
 # Based on https://github.com/ll7/paf21-1/blob/master/components/carla_ros_bridge/Dockerfile
+
+# This is commented out because of the large image download necessary to build this image otherwise.
+# If the PythonAPI/carla version changes, one can comment out the Download Carla PythonAPI line below.
+# Then, uncomment this line and the COPY --from=carla line to build the image.
 # FROM ghcr.io/nylser/carla:leaderboard as carla
 
 # supply the base image with an environment supporting ROS UI via x11
@@ -20,7 +24,8 @@ RUN apt-get update \
 # install dependencies for libgit2 and Carla PythonAPI
 RUN apt-get install wget unzip
 
-# Download Carla PythonAPI
+# Download Carla PythonAPI (alternative to getting it from the Carla-Image, which is commented out above)
+# If the PythonAPI/Carla version changes, either update the link, or refer to the comment at the top of this file.
 RUN wget https://github.com/nylser/carla-leaderboard-PythonAPI/releases/download/v1.0.0/PythonAPI.zip \
   && unzip PythonAPI.zip \
   && rm PythonAPI.zip \

--- a/build/docker/agent/Dockerfile
+++ b/build/docker/agent/Dockerfile
@@ -1,16 +1,15 @@
-
 # Based on https://github.com/ll7/paf21-1/blob/master/components/carla_ros_bridge/Dockerfile
-FROM ghcr.io/nylser/carla:leaderboard as carla
+# FROM ghcr.io/nylser/carla:leaderboard as carla
 
 # supply the base image with an environment supporting ROS UI via x11
 FROM osrf/ros:noetic-desktop-full-focal
-COPY --from=carla /home/carla/PythonAPI /opt/carla/PythonAPI
+
+# COPY --from=carla /home/carla/PythonAPI /opt/carla/PythonAPI
 
 ARG USERNAME=carla
 ARG USER_UID=999
 ARG USER_GID=$USER_UID
 ARG DEBIAN_FRONTEND=noninteractive
-
 
 # install rendering dependencies for rviz / rqt
 RUN apt-get update \
@@ -18,8 +17,15 @@ RUN apt-get update \
     libxext6 libx11-6 libglvnd0 libgl1 \
     libglx0 libegl1 freeglut3-dev
 
-# install dependecy for building libgit2
-RUN apt-get install wget
+# install dependencies for libgit2 and Carla PythonAPI
+RUN apt-get install wget unzip
+
+# Download Carla PythonAPI
+RUN wget https://github.com/nylser/carla-leaderboard-PythonAPI/releases/download/v1.0.0/PythonAPI.zip \
+  && unzip PythonAPI.zip \
+  && rm PythonAPI.zip \
+  && mkdir -p /opt/carla \
+  && mv PythonAPI /opt/carla/PythonAPI
 
 # build libgit2
 RUN wget https://github.com/libgit2/libgit2/archive/refs/tags/v1.5.0.tar.gz -O libgit2-1.5.0.tar.gz \


### PR DESCRIPTION
# Description

Changed the Dockerfile to now require the large Carla image, and download the PythonAPI externally.
This should now greatly decreased the necessary cache size and disk space to build the agent image, hopefully fixing the Github Actions

Fixes #147 

## Time invested

1h @nylser + 0.5h @nylser (documentation)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Does this PR introduce a breaking change?

No

## Most important changes

Changed the source of the PythonAPI folder in the Dockerfile

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (might be obsolete with CI later on)
- [x] New and existing unit tests pass locally with my changes (might be obsolete with CI later on)

